### PR TITLE
chore: add `LICENSE` and `plugin.json`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024 Benson Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,30 @@
+{
+    "pluginmetadataversion": 2,
+    "name": "Mixed Boolean-Arithmetic (MBA) Deobfuscator",
+    "type": [
+        "helper"
+    ],
+    "api": [
+        "python3"
+    ],
+    "description": "Automatically simplify mixed boolean-arithmetic (MBA) obfuscation expressions.",
+    "longdescription": "This script will automatically simplify mixed boolean-arithmetic (MBA) obfuscation expressions used for obfuscation.",
+    "license": {
+        "name": "MIT",
+        "text": "Copyright (c) 2024 Benson Liu\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+    },
+    "platforms": [
+        "Windows",
+        "Linux",
+        "Darwin"
+    ],
+    "installinstructions": {
+        "Windows": "",
+        "Linux": "",
+        "Darwin": ""
+    },
+    "dependencies": {},
+    "version": "0.0.1",
+    "author": "Benson Liu",
+    "minimumbinaryninjaversion": 0
+}


### PR DESCRIPTION
## Summary
Closes #13. Adds `LICENSE` and `plugin.json` metadata to the relevant files for the plugin.

## Test Plan
Can be tested once `__init__.py` is complete and the baseline plugin is loaded into Binary Ninja.
