### PR TITLE
refactor(lint): migrate from black to ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black
-    - name: Analysing the code with black
-      run: black --check *.py **/*.py
+        pip install ruff==0.16.7
+    - name: Analysing the code with ruff
+      run: ruff format --check --diff .

--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ python3 run_experiment.py --help
 ```
 
 ## Contributing
-To contribute to this project, please open a pull request with your changes. If you are unsure about the changes you want to make, please open an issue to discuss it with one of the authors. For code health, please ensure that your code is clear and formatted. You can use the `black` code formatter to format your code. To install `black`, run `pip install black`. To format your code, run the following command.
+To contribute to this project, please open a pull request with your changes. If you are unsure about the changes you want to make, please open an issue to discuss it with one of the authors. For code health, please ensure that your code is clear and formatted. You can use the `ruff` code formatter to format your code. To install `ruff`, run `pip install ruff`. To format your code, run the following command.
 
 ```
-python -m black *.py */*.py
+ruff format .
+```
+
+To check your formatting without rewriting any files, run the following command.
+
+```
+ruff format --check --diff .
 ```
 
 Formatting is checked using a GitHub action, so please ensure that your code is formatted before opening a pull request. We also try and follow good practices by adding type hints to our code.

--- a/experiments/experiment.py
+++ b/experiments/experiment.py
@@ -40,9 +40,9 @@ def run_experiment(
     if n < 2:
         n = 2
 
-    res: list[tuple[int, str, int, str, int, str, int]] = (
-        []
-    )  # (n, original, original_count, obfuscated, obfuscated_count, simplified, simplified_count)
+    res: list[
+        tuple[int, str, int, str, int, str, int]
+    ] = []  # (n, original, original_count, obfuscated, obfuscated_count, simplified, simplified_count)
 
     bg: BooleanGenerator = BooleanGenerator()
     s: Solver = Solver(passes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+target-version = "py313"
+
+[tool.ruff.format]
+docstring-code-format = true


### PR DESCRIPTION
## Summary

Closes #47

Swaps `black` for `ruff` as the formatter. Beyond the tool change, this fixes two things that were making CI failures hard to read:

- **The formatter version is now pinned.** CI installed `black` unpinned, so a new black release could turn a branch red without anyone touching the code. CI now installs `ruff==0.16.7`.
- **The check now covers the whole repo and says what's wrong.** `black --check *.py **/*.py` only reached the top level and one directory deep — anything nested further was silently unchecked. `ruff format --check --diff .` walks the tree (respecting `.gitignore`) and prints the diff it wants, instead of only naming the file.

Changes:

- `.github/workflows/ci.yml` — install `ruff==0.16.7`, run `ruff format --check --diff .`
- `pyproject.toml` (new) — `[tool.ruff]` config so local runs and CI agree on settings
- `README.md` — contributing section now documents `ruff format .` and `ruff format --check --diff .`
- `experiments/experiment.py` — reformatted; the single spot where ruff and black disagree (an annotated assignment carrying a trailing comment)

New dependency: `ruff` (dev only, CI + local formatting). `black` is no longer referenced anywhere in the repo.

## Test Plan

```
$ ruff format --check --diff .
23 files already formatted
```

Exit code 0 — the exact command CI runs, against ruff 0.16.7.

Confirmed the one reformatted file is a pure whitespace change by comparing parse trees before and after:

```
$ python3 -c "import ast; ..."
AST identical: True
```

Also grepped the repo for any remaining `black` reference: no matches.