### PR TITLE
fix(plugin): make MBASED findable in the plugin manager

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "pluginmetadataversion": 2,
-    "name": "Mixed Boolean-Arithmetic (MBA) Deobfuscator",
+    "name": "MBASED: Mixed Boolean-Arithmetic (MBA) Deobfuscator",
     "type": [
         "helper"
     ],
@@ -30,7 +30,7 @@
             "typing_extensions"
         ]
     },
-    "version": "0.0.1",
+    "version": "1.0.0",
     "author": "Benson Liu",
     "minimumbinaryninjaversion": 0
 }


### PR DESCRIPTION
## Summary

No issue — this came out of debugging why the plugin appeared to be missing from the Binary Ninja plugin list.

**It isn't missing.** `bliutech/mbased` is registered in both places: it's the first entry in [community-plugins](https://github.com/Vector35/community-plugins) `listing.json` with a full `plugins.json` record, and it's live on the current service as extension `ef19fb56-b97b-4e2d-8723-ad64aefe94ba` in the Community Extensions manifest — normal state, all six platforms, working download URL.

The problem is that **searching for "MBASED" finds nothing.** The search matches only `name`, `short_description`, and `author_name`, and the string "MBASED" appeared in none of them. The project was findable only by "MBA", "boolean", or "Benson" — not by its own name.

Changes to `plugin.json`:

- `name` → `MBASED: Mixed Boolean-Arithmetic (MBA) Deobfuscator` (51 chars, under the 64-char limit)
- `version` → `1.0.0`. This still read `0.0.1` at the `v1.0.0` tag, so the extension server lists 0.0.1 as the only version. It sorts releases by that string, so leaving it stale risks a future release not registering as new.

No new dependencies.

## Test Plan

Reproduced the original problem against the live site by running its own filter logic over the fetched Community Extensions manifest:

| search term | results before |
|---|---|
| `MBASED` | 0 |
| `MBA` | 1 — this plugin |
| `boolean` | 1 — this plugin |
| `Benson` | 1 — this plugin |

Confirmed in a browser against `extensions.binary.ninja` as well: `MBASED` → 0 cards, `MBA` → 1 card. With the new name, the plugin's `name` field contains "MBASED", so the same substring match hits.

Validated the edited metadata with the upstream validator from the community-plugins repo:

```
$ python3 generate_plugininfo.py -v plugin.json
Successfully validated json file
```

Exit code 0.

## Follow-up (not in this PR)

This metadata only reaches the extension server on a **new release**. After merging, tag and release `v1.1.0` (or re-cut `v1.0.0`) so the server re-reads `plugin.json` — the name change won't show up in the plugin manager until then.