### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -30,7 +30,7 @@
             "typing_extensions"
         ]
     },
-    "version": "1.0.0",
+    "version": "1.1.0",
     "author": "Benson Liu",
     "minimumbinaryninjaversion": 0
 }


### PR DESCRIPTION
## Summary

Prep for cutting the release that carries the `MBASED` name fix from #50 to the Binary Ninja extension server.

#50 set `plugin.json` to `1.0.0`, but the `v1.0.0` tag already exists and points at `66a7472` — so that version can't be cut as a release without colliding. This bumps to `1.1.0`.

Minor rather than patch because the plugin's displayed name changes, which is user-visible in the plugin manager.

No new dependencies.

## Test Plan

Validated with the upstream validator from the community-plugins repo:

```
$ python3 generate_plugininfo.py -v plugin.json
Successfully validated json file
```

Exit code 0.

Confirmed `v1.1.0` does not already exist:

```
$ gh api repos/bliutech/mbased/tags --jq '.[].name'
v1.0.0
```

## After merging

Tag and release `v1.1.0` off `main`. The extension server only re-reads `plugin.json` on a new release, so the name change from #50 does not reach the plugin manager until then.